### PR TITLE
fix 'msg' a nil value error

### DIFF
--- a/auto_mode.lua
+++ b/auto_mode.lua
@@ -23,6 +23,8 @@ The configuration is done in code.
 
 ----- start config
 
+local msg = require "mp.msg"
+
 -- video mode
 
 function on_video_mode_activate()
@@ -156,7 +158,6 @@ end
 
 ----- main
 
-local msg = require "mp.msg"
 active_mode = "video"
 last_type = nil
 


### PR DESCRIPTION
I`m getting this error trying to use auto_mode.lua script:

[auto_mode] Lua error: ...g0apb6-auto_mode-current/share/mpv/scripts/auto_mode.lua:51: attempt to index global 'msg' (a nil value)

This is fix